### PR TITLE
Formatted Number String in Hover Animation

### DIFF
--- a/src/barchart/DataSeries.jsx
+++ b/src/barchart/DataSeries.jsx
@@ -46,7 +46,7 @@ module.exports = React.createClass({
         hoverAnimation={hoverAnimation}
         onMouseOver={this.props.onMouseOver}
         onMouseLeave={this.props.onMouseLeave}
-        dataPoint={{xValue: segment.x, yValue: segment.y, seriesName: this.props.series[seriesIdx]}}
+        dataPoint={{xValue: segment.x, yValue: segment.hoverValue ? segment.hoverValue : segment.y, seriesName: this.props.series[seriesIdx]}}
       />
     )
   }


### PR DESCRIPTION
I'm using rd3 in my app right now, and I wanted to format the value that appears when you hover over a graph. (don't mind the ridiculous numbers for now :smile:)

![screen shot 2016-04-08 at 11 18 24 am](https://cloud.githubusercontent.com/assets/6894526/14395234/c093418e-fd8d-11e5-9e53-f5af62b826a7.png)

![screen shot 2016-04-08 at 11 22 10 am](https://cloud.githubusercontent.com/assets/6894526/14395238/c66b2c98-fd8d-11e5-9091-f451e4a48588.png)

Looking through the source code and the examples I couldn't find a way to do it.. Or I would try to format my x and y value data being passed in to the component but the graphs wouldn't render properly with those values.. please correct me if I'm wrong, and this exists already ^__^

My use case for this is as follows:

``` javascript
         var field_values = {
           "name": "required " + field,
           "values": [
             { "x": "Required Amount",
               "y": this.props["requiredValues"][field],
               "label": this.props["requiredValues"][field],
               "hoverValue": numeral(this.props["requiredValues"][field]).format('0,0')
             },
             { "x": "Actual Amount",
               "y": this.props["actualValues"][field],
               "label": this.props["actualValues"][field],
               "hoverValue": numeral(this.props["actualValues"][field]).format('0,0')
             }
           ]
         }

         var jsx = <BarChart
                    yAxisOffset={90}
                    data={graph_data}
                    width={400}
                    height={300}
                    title={field.split("_").join(" ")}
                   />
```

If a hoverValue is listed in the values object, this will allow for a formatted number string to be used in the _animateBar function in BarContainer.js, instead of the yValue.

Open to whatever feedback, maybe a different implementation would be better, but I think this should be a feature in rd3 regardless.
