### PR TITLE
Added missing xAxisTickCount props to XAxis

### DIFF
--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -87,6 +87,7 @@ module.exports = React.createClass({
               xAxisClassName={props.xAxisClassName}
               strokeWidth={props.xAxisStrokeWidth}
               xAxisTickValues={props.xAxisTickValues}
+              xAxisTickCount={props.xAxisTickCount}
               xAxisTickInterval={props.xAxisTickInterval}
               xAxisOffset={props.xAxisOffset}
               xScale={scales.xScale}


### PR DESCRIPTION
xAxisTickCount missing from LineChart's XAxis. The mixin is not usable from LineChart.
