### PR TITLE
removed duplicate xAccessor/yAccess calls

### DIFF
--- a/src/linechart/DataSeries.jsx
+++ b/src/linechart/DataSeries.jsx
@@ -72,16 +72,9 @@ module.exports = React.createClass({
     let circleFill;
     const regions = voronoi(props.value).map((vnode, idx) => {
       const point = vnode.point.coord;
-      if (Object.prototype.toString.call(xAccessor(point)) === '[object Date]') {
-        cx = props.xScale(xAccessor(point).getTime());
-      } else {
-        cx = props.xScale(xAccessor(point));
-      }
-      if (Object.prototype.toString.call(yAccessor(point)) === '[object Date]') {
-        cy = props.yScale(yAccessor(point).getTime());
-      } else {
-        cy = props.yScale(yAccessor(point));
-      }
+      cx = props.xScale(point.x);
+      cy = props.yScale(point.y);
+
       circleFill = props.colors(props.colorAccessor(vnode, vnode.point.seriesIndex));
 
       return (
@@ -94,8 +87,8 @@ module.exports = React.createClass({
           circleRadius={props.circleRadius}
           onMouseOver={props.onMouseOver}
           dataPoint={{
-            xValue: xAccessor(point),
-            yValue: yAccessor(point),
+            xValue: point.x,
+            yValue: point.y,
             seriesName: vnode.point.series.name,
           }}
         />


### PR DESCRIPTION
Removed the duplicate xAccessor/yAccess calls in _DataSeries.jsx_ that _utils.flattenData_ already takes care of as mention in my issue.
#### comments
- I realized the animation didn't work as well with an xAccessor not equal to (d)=>{return d.x;}. I went ahead and changed those as well. 
- I wasn't able to test directly on repo because when I used 'npm install rd3', everything was still a '.js' file. Please double check it works with your version. It worked on the repo I downloaded using 'npm install'.

Is there a way to install the repo manually or convert to .jsx? 
