### PR TITLE
Change accessor on scatterChart

### DIFF
--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -150,9 +150,9 @@ module.exports = React.createClass({
               height={innerHeight}
               hoverAnimation={props.hoverAnimation}
               width={innerWidth}
-              xAccessor={props.xAccessor}
+              xAccessor={(coord) => coord.x}
               xScale={xScale}
-              yAccessor={props.yAccessor}
+              yAccessor={(coord) => coord.y}
               yScale={yScale}
               onMouseOver={this.onMouseOver}
             />


### PR DESCRIPTION
There is an issue with the accessor if it is different from .x and .y . 
Basically it is applied twice. 
Passing a different accessor to the child fixes the problem.
