### PR TITLE
Added documentation on the accessors and slight mod of the responsive exemple

### DIFF
--- a/docs/new/charts/areaChart.md
+++ b/docs/new/charts/areaChart.md
@@ -16,3 +16,5 @@ interpolationType | string | `null` |
 hoverAnimation | bool | `true` |
 yAxisTickCount |  | `4` |
 className |  | `'rd3-areachart'` |
+xAccessor | func | `d => d.x` |
+yAccessor | func | `d => d.y` |

--- a/docs/new/charts/barChart.md
+++ b/docs/new/charts/barChart.md
@@ -1,6 +1,6 @@
 # Bar Chart
 
-Starting from v0.3.2, we made Bar Chart into a multi-series chart (a stacked chart). So you can pass in props that is supported by [Cartesian Chart](https://github.com/esbullington/react-d3/wiki/CartesianChartPropsMixin) as well. So it supports prop like legend(bool).
+Starting from v0.3.2, we made Bar Chart into a multi-series chart (a stacked chart). So you can pass in props that is supported by [Cartesian Chart](https://github.com/esbullington/react-d3/wiki/CartesianChartPropsMixin) as well. So it supports prop like legend(bool). It also support external y0 accessor for stacked data. Default stays d => d.y0 (as with d3.layout.stack()) but using a custom one is possible.
 
 *However if you want to achieve single-series chart for now, you can pass in a single series data. We're very sorry the inconvenience but a more high level API will be supported in the future to let you disable stacked chart.*
 
@@ -27,6 +27,7 @@ width | number |  |
 xAxisClassName | string | `'rd3-barchart-xaxis'` |
 yAxisClassName | string | `'rd3-barchart-yaxis'` |
 yAxisTickCount | number | `4` |
-xAccessor | any | `d => d.x` |
-yAccessor | any | `d => d.y` |
+xAccessor | func | `d => d.x` |
+yAccessor | func | `d => d.y` |
+y0Accessor | func | `d => d.y0` |
 grouped | bool | `false` | `grouped bar chart`

--- a/docs/new/charts/lineChart.md
+++ b/docs/new/charts/lineChart.md
@@ -18,3 +18,5 @@ domain | object | { x: [], y: [] }  | Specify min and max values for the X and Y
 className |  | `'rd3-linechart'` |
 xAxisClassName |  | `'rd3-linechart-xaxis'` |
 yAxisClassName |  | `'rd3-linechart-yaxis'` |
+xAccessor | func | `d => d.x` |
+yAccessor | func | `d => d.y` |

--- a/docs/new/charts/scatterChart.md
+++ b/docs/new/charts/scatterChart.md
@@ -18,3 +18,5 @@ xAxisClassName | string | `'rd3-scatterchart-xaxis'` |
 xAxisStrokeWidth | number | `1` |
 yAxisClassName | string | `'rd3-scatterchart-yaxis'` |
 yAxisStrokeWidth | number | `1` |
+xAccessor | func | `d => d.x` |
+yAccessor | func | `d => d.y` |

--- a/docs/new/responsiveCharts.md
+++ b/docs/new/responsiveCharts.md
@@ -27,7 +27,7 @@ const createClass = (chartType) => {
       this.state = { size: { w: 0, h: 0 } };
     }
 
-    fitToParentSize() {
+    fitToParentSize = () => {
       const w = this.refs.wrapper.offsetWidth - 20;
       const h = this.refs.wrapper.offsetHeight - 20;
       const currentSize = this.state.size;
@@ -70,16 +70,16 @@ const createClass = (chartType) => {
     }
 
     componentDidMount() {
-      window.addEventListener('resize', ::this.fitToParentSize);
+      window.addEventListener('resize', this.fitToParentSize);
       this.fitToParentSize();
     }
 
     componentWillUnmount() {
-      window.removeEventListener('resize', ::this.fitToParentSize);
+      window.removeEventListener('resize', this.fitToParentSize);
     }
 
     render() {
-      const { duration, margin, ...others } = this.props;
+      const { margin, ...others } = this.props;
       let Component = this.getChartClass();
       let width = this.props.width;
       let height = this.props.height;
@@ -102,7 +102,6 @@ const createClass = (chartType) => {
     },
   };
   Chart.propTypes = {
-    duration: React.PropTypes.array.isRequired,
     width: React.PropTypes.number,
     height: React.PropTypes.number,
     margin: React.PropTypes.object,


### PR DESCRIPTION
So as we said:
•I added the accessor to the documentation
•Documented the .y0 accessor

I also modified the responsive exemple, as I think duration is not needed and the syntax I proposed is more common than the :: used. 

If this is not good github etiquette to ask for two different changes, tell me and I'll split the pull request. Since both issues were in the doc, I felt like I could do both.
