### PR TITLE
Added wrapping for axis tick labels

### DIFF
--- a/src/common/axes/AxisTicks.jsx
+++ b/src/common/axes/AxisTicks.jsx
@@ -222,7 +222,7 @@ module.exports = React.createClass({
               {...optionalTextProps}
             >
               {tickFormat(tick).split('\n').map((tickLabel, index) => (
-                  <tspan x={x1} dy={dy}>
+                  <tspan x={(x1 ? x1 : 0)} dy={dy}>
                     {tickLabel}
                   </tspan>
               ))}

--- a/src/common/axes/AxisTicks.jsx
+++ b/src/common/axes/AxisTicks.jsx
@@ -221,8 +221,8 @@ module.exports = React.createClass({
               textAnchor={textAnchor}
               {...optionalTextProps}
             >
-              {tickFormat(tick).split('\n').map((tickLabel, index) => (
-                  <tspan x={(x1 ? x1 : 0)} dy={dy}>
+              {`${tickFormat(tick)}`.split('\n').map((tickLabel) => (
+                  <tspan x={x1 || 0} dy={dy}>
                     {tickLabel}
                   </tspan>
               ))}

--- a/src/common/axes/AxisTicks.jsx
+++ b/src/common/axes/AxisTicks.jsx
@@ -221,7 +221,11 @@ module.exports = React.createClass({
               textAnchor={textAnchor}
               {...optionalTextProps}
             >
-              {tickFormat(tick)}
+              {tickFormat(tick).split('\n').map((tickLabel, index) => (
+                  <tspan x={0} dy={dy}>
+                    {tickLabel}
+                  </tspan>
+              ))}
             </text>
           </g>
         ))

--- a/src/common/axes/AxisTicks.jsx
+++ b/src/common/axes/AxisTicks.jsx
@@ -222,7 +222,7 @@ module.exports = React.createClass({
               {...optionalTextProps}
             >
               {tickFormat(tick).split('\n').map((tickLabel, index) => (
-                  <tspan x={0} dy={dy}>
+                  <tspan x={x1} dy={dy}>
                     {tickLabel}
                   </tspan>
               ))}


### PR DESCRIPTION
Currently, long labels aren't wrapped on the axes. I updated the render code to support for newline characters. Ideally this should be automatic wrapping on long labels but this was good enough for my purposes and i'll try and add automatic wrapping later. 
