### PR TITLE
Adding common components to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "url": "https://github.com/yang-wei/rd3.git"
   },
   "files": [
-    "build"
+    "build",
+    "src"
   ]
 }


### PR DESCRIPTION
So this is a very manual way of exporting these common components.

Alternatively we could export these under a namespace that's separate from the charts (though I'm not a huge fan of this):

``` js
module.exports.common = require('./common');
```

What I think is the best option though is to include the source files in the npm package so they can be imported individually like in React Toolbox:

``` js
var XAxis = require('rd3/common/XAxis');
```

Let me know what you think.
