### PR TITLE
Adding key to tspan

### DIFF
--- a/src/common/axes/AxisTicks.jsx
+++ b/src/common/axes/AxisTicks.jsx
@@ -221,8 +221,8 @@ module.exports = React.createClass({
               textAnchor={textAnchor}
               {...optionalTextProps}
             >
-              {`${tickFormat(tick)}`.split('\n').map((tickLabel) => (
-                  <tspan x={x1 || 0} dy={dy}>
+              {`${tickFormat(tick)}`.split('\n').map((tickLabel, index) => (
+                  <tspan x={x1 || 0} dy={dy} key={index}>
                     {tickLabel}
                   </tspan>
               ))}


### PR DESCRIPTION
Adding a `key` to `tspan` in a map to prevent this warning:

<img width="480" alt="screen shot 2016-12-02 at 15 37 08" src="https://cloud.githubusercontent.com/assets/9852357/20839645/454cb630-b8a5-11e6-9e63-703ffe01d662.png">
